### PR TITLE
Fix stale cache causing false duplicate image detection

### DIFF
--- a/Addon/content.js
+++ b/Addon/content.js
@@ -186,7 +186,7 @@ async function setupModalLogic(shadow, host, imgUrl) {
     // In the future, this should be identified using a dedicated flag
     // Or use category metadata (e.g. system, visible flags) instead of a hardcoded name.
     if (cat.name === "Uncategorized Favorites") {
-      return; 
+      return;
     }
 
     const div = document.createElement("div");
@@ -288,12 +288,12 @@ async function loadCategories() {
     categoryCache = data.categories;
   } catch {
 
-    categoryCache = [{ name: "Fallback"}];
+    categoryCache = [{ name: "Fallback" }];
 
   }
 
   return categoryCache;
-} 
+}
 
 // =====================
 // DUPLICATE CHECK (LOCAL)
@@ -304,24 +304,41 @@ async function loadCategories() {
 // If an image is removed from the dashboard, this cache is not synced.
 // This may be improved in future versions. 
 
-function isImageAlreadySaved(url) {
-  return new Promise((resolve) => {
+async function isImageAlreadySaved(url) {
+  const list = await new Promise((resolve) => {
     chrome.storage.local.get(["savedImages"], (res) => {
-      const list = res.savedImages || [];
-      resolve(list.includes(url));
+      resolve(res.savedImages || []);
     });
   });
+
+  // Not cached → not duplicate
+  if (!list.includes(url)) return false;
+
+  // Validate with server
+  try {
+    const res = await fetch(
+      `http://127.0.0.1:8000/check-image?url=${encodeURIComponent(url)}`
+    );
+
+    if (!res.ok) throw new Error();
+
+    const data = await res.json();
+
+    // If server says image doesn't exist → remove stale cache
+    if (!data.exists) {
+      const updated = list.filter((u) => u !== url);
+      chrome.storage.local.set({ savedImages: updated });
+      return false;
+    }
+
+    return true;
+
+  } catch (err) {
+    console.warn("Server validation failed, using cache fallback", err);
+    return true; // fallback to cache if server down
+  }
 }
 
-function markImageAsSaved(url) {
-  chrome.storage.local.get(["savedImages"], (res) => {
-    const list = res.savedImages || [];
-    if (!list.includes(url)) {
-      list.push(url);
-      chrome.storage.local.set({ savedImages: list });
-    }
-  });
-}
 
 // =====================
 // IMAGE FINDER

--- a/App/app.py
+++ b/App/app.py
@@ -688,6 +688,28 @@ async def proxy_image(url: str):
         raise HTTPException(status_code=500, detail=str(e))
 
 # =====================
+# IMAGE EXISTENCE CHECK (for extension validation)
+# =====================
+@app.get("/check-image")
+async def check_image(url: str):
+    """
+    Allows extension to verify if an image URL still exists.
+    """
+
+    async with db_lock:
+        images = read_db()
+
+        for img in images:
+            if img.get("originalUrl") == url:
+                # If in trash, treat as non-existent
+                if img.get("isDeleted"):
+                    return {"exists": False}
+                return {"exists": True}
+
+    return {"exists": False}
+
+
+# =====================
 # DEV ENTRY
 # =====================
 if __name__ == "__main__":


### PR DESCRIPTION
Problem:
The extension relied only on chrome.storage for duplicate detection.
When an image was deleted from the dashboard, its URL remained cached,
causing false duplicate warnings.

Solution:
Added `/check-image` endpoint and updated extension duplicate logic
to validate cached URLs against server state. Stale entries are removed
automatically.

Result:
• Accurate duplicate detection
• Self-healing cache
• Dashboard and extension stay consistent
