### PR TITLE
Fix duplicate image handling and button state issues

### DIFF
--- a/Addon/content.js
+++ b/Addon/content.js
@@ -222,7 +222,7 @@ async function handleSave(btn, shadow, host, imgUrl) {
   // 🔒 DUPLICATE CHECK (SERVER'A GİTMEDEN)
   const exists = await isImageAlreadySaved(imgUrl);
   if (exists) {
-    showInlineMessage("⚠️ This image has already been added to your archive");
+    showInlineMessage("⚠️ This image is already archived. If it’s not visible, it might be in the trash.");
     return;
   }
 
@@ -311,20 +311,16 @@ async function isImageAlreadySaved(url) {
     });
   });
 
-  // Not cached → not duplicate
   if (!list.includes(url)) return false;
 
-  // Validate with server
   try {
     const res = await fetch(
       `http://127.0.0.1:8000/check-image?url=${encodeURIComponent(url)}`
     );
 
     if (!res.ok) throw new Error();
-
     const data = await res.json();
 
-    // If server says image doesn't exist → remove stale cache
     if (!data.exists) {
       const updated = list.filter((u) => u !== url);
       chrome.storage.local.set({ savedImages: updated });
@@ -332,11 +328,19 @@ async function isImageAlreadySaved(url) {
     }
 
     return true;
-
-  } catch (err) {
-    console.warn("Server validation failed, using cache fallback", err);
-    return true; // fallback to cache if server down
+  } catch {
+    return true; // fallback
   }
+}
+
+function markImageAsSaved(url) {
+  chrome.storage.local.get(["savedImages"], (res) => {
+    const list = res.savedImages || [];
+    if (!list.includes(url)) {
+      list.push(url);
+      chrome.storage.local.set({ savedImages: list });
+    }
+  });
 }
 
 

--- a/App/app.py
+++ b/App/app.py
@@ -702,8 +702,8 @@ async def check_image(url: str):
         for img in images:
             if img.get("originalUrl") == url:
                 # If in trash, treat as non-existent
-                if img.get("isDeleted"):
-                    return {"exists": False}
+                #if img.get("isDeleted"):
+                #   return {"exists": False}
                 return {"exists": True}
 
     return {"exists": False}


### PR DESCRIPTION
- Fixed button state bug caused by missing markImageAsSaved(imgUrl)
- Added markImageAsSaved implementation
- Improved isImageAlreadySaved logic

- Removed isDeleted handling from check-image endpoint (app.py) This was causing confusing behavior where deleted images could pass the check-image step but were still blocked by add-image due to existing database records.

- As a result, the addon was showing a success state even though the image was not actually added.

- Deleted images cannot be re-added, even if they are in trash. Error message was updated to inform the user that the image may be in the trash if it cannot be found.